### PR TITLE
Added a fix to make the module work inside a virtual environment on Windows

### DIFF
--- a/extension_cpp/__init__.py
+++ b/extension_cpp/__init__.py
@@ -1,2 +1,6 @@
 import torch
+inside_virtual_environment = sys.prefix != sys.base_prefix
+if inside_virtual_environment and os.name == 'nt':
+    dll_dir = os.path.join(sys.prefix, 'Lib\\site-packages\\torch\\lib')
+    handle = os.add_dll_directory(dll_dir)
 from . import _C, ops


### PR DESCRIPTION
On Windows when trying to load the extension, after having compiled it and installed it in a virtual environnement, it failed to load the custom operator. I have traced this issue to a problem related to DLL loading paths.

This change fixes this issue by adding the directory, in the virtual environment, where PyTorch's DLLs are stored, to the DLL search path of Python.
