### PR TITLE
Use linux_job_v2 to get CI to actually work

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
             gpu-arch-type: cuda
             gpu-arch-version: "11.8"
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       repository: pytorch/extension-cpp
       runner: ${{ matrix.runner }}


### PR DESCRIPTION
CI currently breaks today on installing torch. See https://github.com/pytorch/extension-cpp/actions/runs/12896647760/job/35960106353?pr=105 Hopefully this fixes!