### PR TITLE
Create dummymodule _C instead of using load_library(blah.so)

### DIFF
--- a/extension_cpp/__init__.py
+++ b/extension_cpp/__init__.py
@@ -1,10 +1,3 @@
 import torch
 from pathlib import Path
-
-so_files = list(Path(__file__).parent.glob("_C*.so"))
-assert (
-    len(so_files) == 1
-), f"Expected one _C*.so file, found {len(so_files)}"
-torch.ops.load_library(so_files[0])
-
-from . import ops
+from . import _C, ops

--- a/extension_cpp/csrc/muladd.cpp
+++ b/extension_cpp/csrc/muladd.cpp
@@ -7,8 +7,9 @@
 
 extern "C" {
   /* Creates a dummy empty _C module that can be imported from Python.
-     The import from Python will load the .so associated with this extension
-     built from this file, so that all the TORCH_LIBRARY calls below are run.*/
+     The import from Python will load the .so consisting of this file
+     in this extension, so that the TORCH_LIBRARY static initializers
+     below are run. */
   PyObject* PyInit__C(void)
   {
       static struct PyModuleDef module_def = {

--- a/extension_cpp/csrc/muladd.cpp
+++ b/extension_cpp/csrc/muladd.cpp
@@ -1,6 +1,27 @@
-#include <torch/extension.h>
+#include <Python.h>
+#include <ATen/Operators.h>
+#include <torch/all.h>
+#include <torch/library.h>
 
 #include <vector>
+
+extern "C" {
+  /* Creates a dummy empty _C module that can be imported from Python.
+     The import from Python will load the .so associated with this extension
+     built from this file, so that all the TORCH_LIBRARY calls below are run.*/
+  PyObject* PyInit__C(void)
+  {
+      static struct PyModuleDef module_def = {
+          PyModuleDef_HEAD_INIT,
+          "_C",   /* name of module */
+          NULL,   /* module documentation, may be NULL */
+          -1,     /* size of per-interpreter state of the module,
+                     or -1 if the module keeps state in global variables. */
+          NULL,   /* methods */
+      };
+      return PyModule_Create(&module_def);
+  }
+}
 
 namespace extension_cpp {
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ def get_extensions():
         "cxx": [
             "-O3" if not debug_mode else "-O0",
             "-fdiagnostics-color=always",
+            "-DPy_LIMITED_API=0x03090000",
         ],
         "nvcc": [
             "-O3" if not debug_mode else "-O0",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def get_extensions():
         "cxx": [
             "-O3" if not debug_mode else "-O0",
             "-fdiagnostics-color=always",
-            "-DPy_LIMITED_API=0x03090000",
+            "-DPy_LIMITED_API=0x03090000",  # min CPython version 3.9
         ],
         "nvcc": [
             "-O3" if not debug_mode else "-O0",


### PR DESCRIPTION
Following the discussions from the tutorials change, the consensus was to:
- use Py_LIMITED_API flag to guard against bad non CPython agnostic behavior
- create a dummy module _C so that the code is importable instead of calling load_library

THE QUESTION IS: do we prefer this approach over the torch.ops.load_library(so_file) approach?

This was tested locally -- tests pass and the wheel is CPython agnostic.