### PR TITLE
Fix typo

### DIFF
--- a/extension_cpp/csrc/muladd.cpp
+++ b/extension_cpp/csrc/muladd.cpp
@@ -90,7 +90,7 @@ TORCH_LIBRARY(extension_cpp, m) {
   m.def("myadd_out(Tensor a, Tensor b, Tensor(a!) out) -> ()");
 }
 
-// Registers CUDA implementations for mymuladd, mymul, myadd_out
+// Registers C++ implementations for mymuladd, mymul, myadd_out
 TORCH_LIBRARY_IMPL(extension_cpp, CPU, m) {
   m.impl("mymuladd", &mymuladd_cpu);
   m.impl("mymul", &mymul_cpu);


### PR DESCRIPTION
Rename `CUDA` to `C++` for C++ implementations