### PR TITLE
Fix semver comparison logic

### DIFF
--- a/extension_cpp/requirements.txt
+++ b/extension_cpp/requirements.txt
@@ -1,2 +1,3 @@
 torch
 numpy
+packaging

--- a/extension_cpp/setup.py
+++ b/extension_cpp/setup.py
@@ -8,6 +8,7 @@ import torch
 import glob
 
 from setuptools import find_packages, setup
+from packaging.version import Version
 
 from torch.utils.cpp_extension import (
     CppExtension,
@@ -18,10 +19,7 @@ from torch.utils.cpp_extension import (
 
 library_name = "extension_cpp"
 
-if torch.__version__ >= "2.6.0":
-    py_limited_api = True
-else:
-    py_limited_api = False
+py_limited_api = Version(torch.__version__) >= Version("2.6.0")
 
 
 def get_extensions():

--- a/extension_cpp_stable/requirements.txt
+++ b/extension_cpp_stable/requirements.txt
@@ -1,2 +1,3 @@
 torch
 numpy
+packaging

--- a/extension_cpp_stable/setup.py
+++ b/extension_cpp_stable/setup.py
@@ -8,6 +8,7 @@ import torch
 import glob
 
 from setuptools import find_packages, setup
+from packaging.version import Version
 
 from torch.utils.cpp_extension import (
     CppExtension,
@@ -19,10 +20,7 @@ from torch.utils.cpp_extension import (
 library_name = "extension_cpp_stable"
 
 
-if torch.__version__ >= "2.6.0":
-    py_limited_api = True
-else:
-    py_limited_api = False
+py_limited_api = Version(torch.__version__) >= Version("2.6.0")
 
 
 def get_extensions():


### PR DESCRIPTION
Fix PyTorch version check in `setup.py` to use semantic versioning instead of string comparison. Former lexicographical comparison `if torch.__version__ >= "2.6.0"` is unsafe
```bash
>>> "2.10.0" >= "2.6.0"
False
```

while utilizing `packaging.version.Version` ensures correct semantic comparison 
```bash
>>> Version("2.10.0") >= Version("2.6.0")
True
```