### PR TITLE
Error when loading extension_cpp_stable

### DIFF
--- a/extension_cpp_stable/extension_cpp_stable/__init__.py
+++ b/extension_cpp_stable/extension_cpp_stable/__init__.py
@@ -1,1 +1,3 @@
+import torch
+from pathlib import Path
 from . import _C, ops  # noqa: F401


### PR DESCRIPTION
# Background
I was using `extension_cpp_stable` as a baseline to expand my own project into a Cuda backed library. 
`pip install .` and `pip install -e .` would work fine within the `extension_cpp_stable` folder.
However, an **ImportError: libtorch_cuda.so: cannot open shared object file: No such file or directory** would occur at runtime.

# Test environment
The test environment does not catch this error, since `extension_cpp` is loaded before / the `torch` module is loaded before the testing of `extension_cpp_stable` starts.

# Fix
To fix this `torch` must be imported before `from . import _C` is executed.
This is already been done in the `extension_cpp` package.
Hence, I based my solution on the existing code.

# Hope this helps someone in the future :)
